### PR TITLE
Implement Clone for `DieselMiddleware`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,22 @@ where
     }
 }
 
+impl<T> Clone for DieselMiddleware<T>
+where
+    T: Connection + 'static,
+{
+    fn clone(&self) -> Self {
+        match catch_unwind(|| self.pool.clone()) {
+            Ok(pool) => DieselMiddleware { pool: AssertUnwindSafe(pool) },
+            Err(_) => {
+                error!("PANIC: r2d2::Pool::clone caused a panic");
+                eprintln!("PANIC: r2d2::Pool::clone caused a panic");
+                process::abort()
+            }
+        }
+    }
+}
+
 impl<T> Middleware for DieselMiddlewareImpl<T>
 where
     T: Connection + 'static,


### PR DESCRIPTION
We need the ability to pass a single `DieselMiddleware` instance to multiple router instances for modular Gotham applications which is enabled by this commit.

Supporting this ensures that the Diesel Middleware can me made part of pipelines where it is necessary thus not being traversed application wide e.g. endpoints/controllers that have no need for
database interaction.