### PR TITLE
Update to diesel 0.99 and r2d2 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ futures = "0.1.0"
 gotham = { path = "../gotham" }
 gotham_derive = { path = "../gotham/gotham_derive" }
 
-diesel = { version = "0.16.0", features = ["postgres", "sqlite", "mysql"] }
-r2d2 = "0.7.0"
-r2d2-diesel = "0.16.0"
+diesel = { version = "0.99.0", features = ["postgres", "sqlite", "mysql"] }
+r2d2 = "0.8.1"
+r2d2-diesel = "0.99.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ futures = "0.1.0"
 gotham = { path = "../gotham" }
 gotham_derive = { path = "../gotham/gotham_derive" }
 
-diesel = { version = "0.99.0", features = ["postgres", "sqlite", "mysql"] }
+diesel = { version = "1.0.0-beta1", features = ["postgres", "sqlite", "mysql"] }
 r2d2 = "0.8.1"
-r2d2-diesel = "0.99.0"
+r2d2-diesel = "1.0.0-beta1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,22 +155,22 @@ where
 mod tests {
     use super::*;
 
-    use diesel::pg::PgConnection;
+    use diesel::sqlite::SqliteConnection;
     use r2d2_diesel::ConnectionManager;
 
+    static DATABASE_URL: &'static str = ":memory:";
+
     #[test]
-    #[ignore]
     fn new_with_default_config() {
-        let manager = ConnectionManager::new("postgres://user:password@localhost");
-        let pool = Pool::<ConnectionManager<PgConnection>>::new(manager).unwrap();
+        let manager = ConnectionManager::new(DATABASE_URL);
+        let pool = Pool::<ConnectionManager<SqliteConnection>>::new(manager).unwrap();
         let _middleware = DieselMiddleware::with_pool(pool);
     }
 
     #[test]
-    #[ignore]
     fn new_with_custom_pool_config() {
-        let manager = ConnectionManager::new("postgres://user:password@localhost");
-        let pool = Pool::<ConnectionManager<PgConnection>>::builder()
+        let manager = ConnectionManager::new(DATABASE_URL);
+        let pool = Pool::<ConnectionManager<SqliteConnection>>::builder()
             .min_idle(Some(1))
             .build(manager)
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,7 @@ where
 
         let pool = Pool::<ConnectionManager<T>>::new(manager).expect("Failed to create pool.");
 
-        DieselMiddleware {
-            pool: AssertUnwindSafe(pool),
-        }
+        DieselMiddleware::with_pool(pool)
     }
 
     /// Sets up a new instance of the middleware and establishes a connection to the database.

--- a/src/state_data.rs
+++ b/src/state_data.rs
@@ -2,11 +2,11 @@
 //! pool so a connection can be established if required by Middleware or Handlers.
 
 use diesel::Connection;
-use r2d2::{GetTimeout, Pool, PooledConnection};
+use r2d2::{Error, Pool, PooledConnection};
 use r2d2_diesel::ConnectionManager;
 
 use gotham;
-use gotham::state::{State, FromState};
+use gotham::state::{FromState, State};
 
 /// Convenience function for usage within 3rd party Middleware and Handlers to obtain a
 /// Diesel connection.
@@ -17,14 +17,14 @@ pub fn connection<T>(s: &State) -> PooledConnection<ConnectionManager<T>>
 where
     T: Connection + 'static,
 {
-    Diesel::borrow_from(s).conn().expect(
-        "Did not obtain valid Diesel connection from R2D2 pool",
-    )
+    Diesel::borrow_from(s)
+        .conn()
+        .expect("Did not obtain valid Diesel connection from R2D2 pool")
 }
 
 /// Convenience function for usage within 3rd party Middleware and Handlers to obtain a
 /// Diesel connection.
-pub fn try_connection<T>(s: &State) -> Result<PooledConnection<ConnectionManager<T>>, GetTimeout>
+pub fn try_connection<T>(s: &State) -> Result<PooledConnection<ConnectionManager<T>>, Error>
 where
     T: Connection + 'static,
 {
@@ -49,7 +49,7 @@ where
     }
 
     /// Provides access to a Diesel connection from our r2d2 backed connection pool.
-    pub fn conn(&self) -> Result<PooledConnection<ConnectionManager<T>>, GetTimeout> {
+    pub fn conn(&self) -> Result<PooledConnection<ConnectionManager<T>>, Error> {
         self.pool.get()
     }
 }


### PR DESCRIPTION
This update Diesel to v0.99 and r2d2 to v0.8.1 (both latest available). I had to remove the configuration option on the middleware constructor as that [has been removed from the r2d2 lib](https://github.com/sfackler/r2d2/blob/06a52109609a1cbf5771053250e5574cc5e644dc/CHANGELOG.md#changed).