### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+
+branches:
+  only:
+  - master
+
+cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
   - beta
   - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
 
 branches:
   only:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["http", "async", "web", "framework", "gotham"]
 [dependencies]
 log = "0.3.0"
 futures = "0.1.0"
-gotham = { path = "../gotham" }
-gotham_derive = { path = "../gotham/gotham_derive" }
+gotham = { git = "https://github.com/gotham-rs/gotham" }
+gotham_derive = { git = "https://github.com/gotham-rs/gotham" }
 
 diesel = { version = "0.16.0", features = ["postgres", "sqlite", "mysql"] }
 r2d2 = "0.7.0"


### PR DESCRIPTION
This adds a basic Travis configuration that will build and test this middleware. Since the gotham version required for the current master branch has not been released yet, I've added it as git dependency.