### PR TITLE
Selectively enable diesel backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,17 @@ readme = "README.md"
 categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "framework", "gotham"]
 
+[features]
+postgres = ["diesel/postgres"]
+sqlite = ["diesel/sqlite"]
+mysql = ["diesel/mysql"]
+
 [dependencies]
 log = "0.3.0"
 futures = "0.1.0"
 gotham = { git = "https://github.com/gotham-rs/gotham" }
 gotham_derive = {  git = "https://github.com/gotham-rs/gotham" }
 
-diesel = { version = "1.0.0-beta1", features = ["postgres", "sqlite", "mysql"] }
+diesel = { version = "1.0.0-beta1" }
 r2d2 = "0.8.1"
 r2d2-diesel = "1.0.0-beta1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["http", "async", "web", "framework", "gotham"]
 [dependencies]
 log = "0.3.0"
 futures = "0.1.0"
-gotham = { path = "../gotham" }
-gotham_derive = { path = "../gotham/gotham_derive" }
+gotham = { git = "https://github.com/gotham-rs/gotham" }
+gotham_derive = {  git = "https://github.com/gotham-rs/gotham" }
 
 diesel = { version = "1.0.0-beta1", features = ["postgres", "sqlite", "mysql"] }
 r2d2 = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ gotham_derive = {  git = "https://github.com/gotham-rs/gotham" }
 diesel = { version = "1.0.0-beta1" }
 r2d2 = "0.8.1"
 r2d2-diesel = "1.0.0-beta1"
+
+[dev-dependencies]
+diesel = { features = ["sqlite"] }


### PR DESCRIPTION
This PR introduces features into middleware-diesel that delegate into diesel itself, that indicate what backend(s?) are required for compilation.

This ensures that linked client libraries are kept minimal when deploying to production.

Existing users of middleware-diesel will need to alter Cargo as follows, adding the [`features` which are provided by diesel](https://github.com/diesel-rs/diesel/blob/9e341a433121049ade044d12fa4752ae09aafa67/diesel/Cargo.toml#L48) as suitable for their backend as follows:

``` toml
gotham_middleware_diesel = { ... , features = ["postgres"] }
# or
gotham_middleware_diesel = { ... , features = ["mysql"] }
# or
gotham_middleware_diesel = { ... , features = ["sqlite"] }
```